### PR TITLE
Assign default element role to button

### DIFF
--- a/src/clipboard-copy-element.js
+++ b/src/clipboard-copy-element.js
@@ -86,5 +86,9 @@ export default class ClipboardCopyElement extends HTMLElement {
     if (!this.hasAttribute('tabindex')) {
       this.setAttribute('tabindex', '0')
     }
+
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'button')
+    }
   }
 }


### PR DESCRIPTION
Advertise the custom element as a [clickable button](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role) to screen readers. This default complements the existing `tabindex` attribute and <kbd>Space</kbd> and <kbd>Enter</kbd> key handling.

