### PR TITLE
Include flow type definitions in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,17 +9,15 @@
     "clean": "rm -rf dist",
     "lint": "eslint src/ && flow check",
     "prebuild": "npm run clean && npm run lint",
-    "build": "rollup -c && rollup -c rollup.config.umd.js",
+    "build-umd": "rollup -c rollup.config.umd.js && cp src/clipboard-copy-element.js.flow dist/index.umd.js.flow",
+    "build-esm": "rollup -c && cp src/clipboard-copy-element.js.flow dist/index.esm.js.flow",
+    "build": "npm run build-umd && npm run build-esm",
     "test": "npm run lint",
     "prepublishOnly": "npm run build"
   },
-  "keywords": [
-    "clipboard"
-  ],
+  "keywords": ["clipboard"],
   "license": "MIT",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-custom-element-classes": "^0.1.0",

--- a/src/clipboard-copy-element.js.flow
+++ b/src/clipboard-copy-element.js.flow
@@ -1,0 +1,8 @@
+/* @flow */
+
+declare class ClipboardCopyElement extends HTMLElement {
+  get copiedLabel(): ?string;
+  set copiedLabel(value: string): void;
+  get value(): ?string;
+  set value(value: string): void;
+}


### PR DESCRIPTION
Declares the element's class as a global because it's exported to `window`. The type definitions allow Flow to type check the value property accessor.

```js
const el = new ClipboardCopyElement()
el.value = 'hubot'
```