### PR TITLE
Improve button focus handling for accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ import 'clipboard-copy-element'
 ```html
 <clipboard-copy
       for="blob-path"
-      class="btn btn-sm BtnGroup-item tooltipped tooltipped-s"
-      aria-label="Copy file path to clipboard"
-      copied-label="Copied!">
+      class="btn btn-sm BtnGroup-item"
+      title="Copy file path to clipboard"
+      copied-label="Copied!"
+      copied-class="tooltipped tooltipped-s">
   Copy path
 </clipboard-copy>
 <div id="blob-path">src/index.js</div>
@@ -49,9 +50,12 @@ import 'clipboard-copy-element'
 
 ## Tooltips
 
-After copying to the clipboard an optional tooltip can be displayed as
+After copying to the clipboard, an optional tooltip can be displayed as
 confirmation. The button temporarily replaces the `aria-label` attribute
 value with the `copied-label` attribute to display the tooltip.
+
+The class names in the `copied-class` attribute are applied to the button
+while the tooltip is displayed.
 
 Styles for the tooltip can be provided by the host application or a component
 system like [Primer][].

--- a/src/clipboard-copy-element.js
+++ b/src/clipboard-copy-element.js
@@ -36,17 +36,15 @@ function applyHint(button: Element) {
   if (!hint || hint === original) return
 
   button.setAttribute('aria-label', hint)
-  button.addEventListener(
-    'mouseleave',
-    () => {
-      if (original != null) {
-        button.setAttribute('aria-label', original)
-      } else {
-        button.removeAttribute('aria-label')
-      }
-    },
-    {once: true}
-  )
+
+  const reset = () => {
+    if (original != null) {
+      button.setAttribute('aria-label', original)
+    } else {
+      button.removeAttribute('aria-label')
+    }
+  }
+  button.addEventListener('mouseleave', reset, {once: true})
 }
 
 function clicked(event: MouseEvent) {

--- a/src/clipboard-copy-element.js
+++ b/src/clipboard-copy-element.js
@@ -12,7 +12,6 @@ function copy(button: HTMLElement) {
   }
 
   applyHint(button)
-  button.blur()
 }
 
 function copyTarget(document: Document, id: string) {
@@ -37,7 +36,15 @@ function applyHint(button: Element) {
 
   button.setAttribute('aria-label', hint)
 
+  const classes = (button.getAttribute('copied-class') || '').split(' ')
+  if (classes.length) {
+    button.classList.add(...classes)
+  }
+
   const reset = () => {
+    if (classes.length) {
+      button.classList.remove(...classes)
+    }
     if (original != null) {
       button.setAttribute('aria-label', original)
     } else {
@@ -45,6 +52,7 @@ function applyHint(button: Element) {
     }
   }
   button.addEventListener('mouseleave', reset, {once: true})
+  button.addEventListener('blur', reset, {once: true})
 }
 
 function clicked(event: MouseEvent) {
@@ -96,6 +104,14 @@ export default class ClipboardCopyElement extends HTMLElement {
 
   set copiedLabel(text: string) {
     this.setAttribute('copied-label', text)
+  }
+
+  get copiedClass(): string {
+    return this.getAttribute('copied-class') || ''
+  }
+
+  set copiedClass(value: string) {
+    this.setAttribute('copied-class', value)
   }
 
   get value(): string {

--- a/src/clipboard-copy-element.js
+++ b/src/clipboard-copy-element.js
@@ -92,16 +92,16 @@ export default class ClipboardCopyElement extends HTMLElement {
     }
   }
 
-  get copiedLabel(): ?string {
-    return this.getAttribute('copied-label')
+  get copiedLabel(): string {
+    return this.getAttribute('copied-label') || ''
   }
 
   set copiedLabel(text: string) {
     this.setAttribute('copied-label', text)
   }
 
-  get value(): ?string {
-    return this.getAttribute('value')
+  get value(): string {
+    return this.getAttribute('value') || ''
   }
 
   set value(text: string) {

--- a/src/clipboard-copy-element.js
+++ b/src/clipboard-copy-element.js
@@ -33,20 +33,20 @@ function copyTarget(document: Document, id: string) {
 function applyHint(button: Element) {
   const hint = button.getAttribute('copied-label')
   const original = button.getAttribute('aria-label')
-  if (hint && hint !== original) {
-    button.setAttribute('aria-label', hint)
-    button.addEventListener(
-      'mouseleave',
-      () => {
-        if (original != null) {
-          button.setAttribute('aria-label', original)
-        } else {
-          button.removeAttribute('aria-label')
-        }
-      },
-      {once: true}
-    )
-  }
+  if (!hint || hint === original) return
+
+  button.setAttribute('aria-label', hint)
+  button.addEventListener(
+    'mouseleave',
+    () => {
+      if (original != null) {
+        button.setAttribute('aria-label', original)
+      } else {
+        button.removeAttribute('aria-label')
+      }
+    },
+    {once: true}
+  )
 }
 
 function clicked(event: MouseEvent) {

--- a/src/clipboard-copy-element.js.flow
+++ b/src/clipboard-copy-element.js.flow
@@ -3,6 +3,8 @@
 declare class ClipboardCopyElement extends HTMLElement {
   get copiedLabel(): string;
   set copiedLabel(value: string): void;
+  get copiedClass(): string;
+  set copiedClass(value: string): void;
   get value(): string;
   set value(value: string): void;
 }

--- a/src/clipboard-copy-element.js.flow
+++ b/src/clipboard-copy-element.js.flow
@@ -1,8 +1,8 @@
 /* @flow */
 
 declare class ClipboardCopyElement extends HTMLElement {
-  get copiedLabel(): ?string;
+  get copiedLabel(): string;
   set copiedLabel(value: string): void;
-  get value(): ?string;
+  get value(): string;
   set value(value: string): void;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -11,4 +11,45 @@ describe('clipboard-copy element', function() {
       assert.equal('CLIPBOARD-COPY', el.nodeName)
     })
   })
+
+  describe('clicking the button', function() {
+    beforeEach(function() {
+      const container = document.createElement('div')
+      container.innerHTML = `
+        <clipboard-copy
+            value="target text"
+            aria-label="Copy to clipboard"
+            copied-label="Copied!"
+            copied-class="tooltipped">
+          Copy
+        </clipboard-copy>`
+      document.body.append(container)
+    })
+
+    afterEach(function() {
+      document.body.innerHTML = ''
+    })
+
+    it('retains focus on the button', function() {
+      const button = document.querySelector('clipboard-copy')
+      button.focus()
+      assert.equal(document.activeElement, button)
+      button.click()
+      assert.equal(document.activeElement, button)
+    })
+
+    it('restores tooltip text and classes on blur', function() {
+      const button = document.querySelector('clipboard-copy')
+      assert.equal('Copy to clipboard', button.getAttribute('aria-label'))
+      button.focus()
+
+      button.click()
+      assert.equal('Copied!', button.getAttribute('aria-label'))
+      assert(button.classList.contains('tooltipped'))
+
+      button.blur()
+      assert.equal('Copy to clipboard', button.getAttribute('aria-label'))
+      assert(!button.classList.contains('tooltipped'))
+    })
+  })
 })


### PR DESCRIPTION
We are blurring the button following activation as a side-effect of how tooltips are displayed. Ideally, the button should remain focused so that tabbing continues from there rather than resetting on `<body>`.

> If activating the button does not dismiss the current context, then focus typically remains on the button after activation,
—https://www.w3.org/TR/wai-aria-practices/#button

This branch retains focus on the button after activation, either through a mouse click or <kbd>Space</kbd> or <kbd>Enter</kbd>, and introduces a `copied-class` attribute for tooltip class names to apply to the button while the tooltip is displayed.