### PR TITLE
Support copying href of target anchor element

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ import 'clipboard-copy-element'
 <input id="blob-path" value="src/index.js">
 ```
 
+### Hyperlink href
+
+```html
+<clipboard-copy for="blob-path">Copy</clipboard-copy>
+<a id="blob-path" href="/path/to#my-blob">This will not be copied</a>
+```
+
 ## Events
 
 After copying to the clipboard, a [copy][] event is dispatched that can be

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ import 'clipboard-copy-element'
 ### Hyperlink href
 
 ```html
-<clipboard-copy for="blob-path">Copy</clipboard-copy>
-<a id="blob-path" href="/path/to#my-blob">This will not be copied</a>
+<clipboard-copy for="blob-path">Copy full URL</clipboard-copy>
+<a id="blob-path" href="/path/to#my-blob">Link text will not be copied</a>
 ```
 
 ## Events

--- a/src/clipboard-copy-element.js
+++ b/src/clipboard-copy-element.js
@@ -22,6 +22,8 @@ function copyTarget(button: Element, id: string) {
     } else {
       copyInput(button, content)
     }
+  } else if (content instanceof HTMLAnchorElement && content.hasAttribute('href')) {
+    copyText(button, content.href)
   } else {
     copyNode(button, content)
   }

--- a/test/test.js
+++ b/test/test.js
@@ -34,4 +34,101 @@ describe('clipboard-copy element', function() {
       assert.equal(document.activeElement, button)
     })
   })
+
+  describe('target element', function() {
+    const nativeClipboard = navigator.clipboard
+    function defineClipboard(customClipboard) {
+      Object.defineProperty(navigator, 'clipboard', {
+        enumerable: false,
+        configurable: true,
+        get() {
+          return customClipboard
+        }
+      })
+    }
+
+    let whenCopied
+    beforeEach(function() {
+      const container = document.createElement('div')
+      container.innerHTML = `
+        <clipboard-copy for="copy-target">
+          Copy
+        </clipboard-copy>`
+      document.body.append(container)
+
+      let copiedText = null
+      defineClipboard({
+        writeText(text) {
+          copiedText = text
+          return Promise.resolve()
+        }
+      })
+
+      whenCopied = new Promise(resolve => {
+        document.addEventListener('copy', () => resolve(copiedText), {once: true})
+      })
+    })
+
+    afterEach(function() {
+      document.body.innerHTML = ''
+      defineClipboard(nativeClipboard)
+    })
+
+    it('node', function() {
+      const target = document.createElement('div')
+      target.innerHTML = 'Hello <b>world!</b>'
+      target.id = 'copy-target'
+      document.body.append(target)
+
+      const button = document.querySelector('clipboard-copy')
+      button.click()
+
+      return whenCopied.then(text => {
+        assert.equal(text, 'Hello world!')
+      })
+    })
+
+    it('hidden input', function() {
+      const target = document.createElement('input')
+      target.type = 'hidden'
+      target.value = 'Hello world!'
+      target.id = 'copy-target'
+      document.body.append(target)
+
+      const button = document.querySelector('clipboard-copy')
+      button.click()
+
+      return whenCopied.then(text => {
+        assert.equal(text, 'Hello world!')
+      })
+    })
+
+    it('input field', function() {
+      const target = document.createElement('input')
+      target.value = 'Hello world!'
+      target.id = 'copy-target'
+      document.body.append(target)
+
+      const button = document.querySelector('clipboard-copy')
+      button.click()
+
+      return whenCopied.then(text => {
+        assert.equal(text, 'Hello world!')
+      })
+    })
+
+    it('textarea', function() {
+      const target = document.createElement('textarea')
+      target.value = 'Hello world!'
+      target.id = 'copy-target'
+      document.body.append(target)
+
+      const button = document.querySelector('clipboard-copy')
+      button.click()
+
+      return whenCopied.then(text => {
+        assert.equal(text, 'Hello world!')
+      })
+    })
+  })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -130,5 +130,34 @@ describe('clipboard-copy element', function() {
         assert.equal(text, 'Hello world!')
       })
     })
+
+    it('a[href]', function() {
+      const target = document.createElement('a')
+      target.href = '/hello#world'
+      target.textContent = 'I am a link'
+      target.id = 'copy-target'
+      document.body.append(target)
+
+      const button = document.querySelector('clipboard-copy')
+      button.click()
+
+      return whenCopied.then(text => {
+        assert.equal(text, `${location.origin}/hello#world`)
+      })
+    })
+
+    it('a[id]', function() {
+      const target = document.createElement('a')
+      target.textContent = 'I am a link'
+      target.id = 'copy-target'
+      document.body.append(target)
+
+      const button = document.querySelector('clipboard-copy')
+      button.click()
+
+      return whenCopied.then(text => {
+        assert.equal(text, 'I am a link')
+      })
+    })
   })
 })


### PR DESCRIPTION
When the `for="target-id"` attribute matches a hyperlink element with a `href` attribute, copy that element's `.href` property to clipboard.