### PR TITLE
Export `copyInput`, `copyNode`, `copyText` functions from module

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,15 @@ import 'clipboard-copy-element'
 
 ## Events
 
-After copying to the clipboard, a [copy][] event is dispatched that can be
-used to notify the user with confirmation, like a tooltip or button highlight.
+After copying to the clipboard, a `clipboard-copied` event is dispatched from
+the `<clipboard-copy>` element:
 
 ```js
-document.addEventListener('copy', function(event) {
-  const button = document.activeElement
+document.addEventListener('clipboard-copied', function(event) {
+  const button = event.target
   button.classList.add('highlight')
 })
 ```
-
-[copy]: https://developer.mozilla.org/en-US/docs/Web/Events/copy
 
 ## Browser support
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -10,7 +10,7 @@
       }
     </style>
     <script>
-      document.addEventListener('copy', function() {
+      document.addEventListener('clipboard-copied', function() {
         const notice = document.getElementById('notice')
         notice.hidden = false
         setTimeout(function() {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,6 +12,7 @@ export default {
       format: 'es'
     },
     {
+      name: 'ClipboardCopyElementMethods',
       file: pkg['main'],
       format: 'umd'
     }

--- a/src/clipboard-copy-element.js
+++ b/src/clipboard-copy-element.js
@@ -6,24 +6,22 @@ function copy(button: HTMLElement) {
   const id = button.getAttribute('for')
   const text = button.getAttribute('value')
   if (text) {
-    copyText(button, text)
+    copyText(text)
   } else if (id) {
-    copyTarget(button, id)
+    const node = button.ownerDocument.getElementById(id)
+    if (node) copyTarget(node)
   }
 }
 
-function copyTarget(button: Element, id: string) {
-  const content = button.ownerDocument.getElementById(id)
-  if (!content) return
-
+function copyTarget(content: Element) {
   if (content instanceof HTMLInputElement || content instanceof HTMLTextAreaElement) {
     if (content.type === 'hidden') {
-      copyText(button, content.value)
+      copyText(content.value)
     } else {
-      copyInput(button, content)
+      copyInput(content)
     }
   } else {
-    copyNode(button, content)
+    copyNode(content)
   }
 }
 

--- a/src/clipboard-copy-element.js
+++ b/src/clipboard-copy-element.js
@@ -5,23 +5,28 @@ import {copyInput, copyNode, copyText} from './clipboard'
 function copy(button: HTMLElement) {
   const id = button.getAttribute('for')
   const text = button.getAttribute('value')
+
+  function trigger() {
+    button.dispatchEvent(new CustomEvent('clipboard-copied', {bubbles: true}))
+  }
+
   if (text) {
-    copyText(text)
+    copyText(text).then(trigger)
   } else if (id) {
     const node = button.ownerDocument.getElementById(id)
-    if (node) copyTarget(node)
+    if (node) copyTarget(node).then(trigger)
   }
 }
 
 function copyTarget(content: Element) {
   if (content instanceof HTMLInputElement || content instanceof HTMLTextAreaElement) {
     if (content.type === 'hidden') {
-      copyText(content.value)
+      return copyText(content.value)
     } else {
-      copyInput(content)
+      return copyInput(content)
     }
   } else {
-    copyNode(content)
+    return copyNode(content)
   }
 }
 

--- a/src/clipboard-copy-element.js.flow
+++ b/src/clipboard-copy-element.js.flow
@@ -4,3 +4,9 @@ declare class ClipboardCopyElement extends HTMLElement {
   get value(): string;
   set value(value: string): void;
 }
+
+declare module.exports: {
+  copyInput(node: HTMLInputElement | HTMLTextAreaElement): Promise<void>;
+  copyNode(node: Element): Promise<void>;
+  copyText(text: string): Promise<void>;
+}

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -11,12 +11,15 @@ function createNode(text: string): Element {
   return node
 }
 
-export function copyNode(button: Element, node: Element) {
-  if (writeAsync(button, node.textContent)) return
+export function copyNode(node: Element): Promise<void> {
+  if ('clipboard' in navigator) {
+    // $FlowFixMe Clipboard is not defined in Flow yet.
+    return navigator.clipboard.writeText(node.textContent)
+  }
 
   const selection = getSelection()
   if (selection == null) {
-    return
+    return Promise.reject(new Error())
   }
 
   selection.removeAllRanges()
@@ -27,22 +30,32 @@ export function copyNode(button: Element, node: Element) {
 
   document.execCommand('copy')
   selection.removeAllRanges()
+  return Promise.resolve()
 }
 
-export function copyText(button: Element, text: string) {
-  if (writeAsync(button, text)) return
+export function copyText(text: string): Promise<void> {
+  if ('clipboard' in navigator) {
+    // $FlowFixMe Clipboard is not defined in Flow yet.
+    return navigator.clipboard.writeText(text)
+  }
 
   const body = document.body
-  if (!body) return
+  if (!body) {
+    return Promise.reject(new Error())
+  }
 
   const node = createNode(text)
   body.appendChild(node)
-  copyNode(button, node)
+  copyNode(node)
   body.removeChild(node)
+  return Promise.resolve()
 }
 
-export function copyInput(button: Element, node: HTMLInputElement | HTMLTextAreaElement) {
-  if (writeAsync(button, node.value)) return
+export function copyInput(node: HTMLInputElement | HTMLTextAreaElement): Promise<void> {
+  if ('clipboard' in navigator) {
+    // $FlowFixMe Clipboard is not defined in Flow yet.
+    return navigator.clipboard.writeText(node.value)
+  }
 
   node.select()
   document.execCommand('copy')
@@ -50,15 +63,5 @@ export function copyInput(button: Element, node: HTMLInputElement | HTMLTextArea
   if (selection != null) {
     selection.removeAllRanges()
   }
-}
-
-function writeAsync(button: Element, text: string): boolean {
-  // $FlowFixMe Clipboard is not defined in Flow yet.
-  const clipboard = navigator.clipboard
-  if (!clipboard) return false
-
-  clipboard.writeText(text).then(function() {
-    button.dispatchEvent(new CustomEvent('copy', {bubbles: true}))
-  })
-  return true
+  return Promise.resolve()
 }

--- a/src/index.js
+++ b/src/index.js
@@ -6,3 +6,5 @@ if (!window.customElements.get('clipboard-copy')) {
   window.ClipboardCopyElement = ClipboardCopyElement
   window.customElements.define('clipboard-copy', ClipboardCopyElement)
 }
+
+export {copyInput, copyNode, copyText} from './clipboard'


### PR DESCRIPTION
I thought that these functions may be useful enough to programatically use directly, especially `copyText`. However, several changes were required to make that happen:

1. The method signature of these functions all accepted `button` as the first argument for the sole purpose of conditionally firing a `copy` event from it. This is not applicable for programmatic use of these functions, since there might not be a button where the copy interaction started, so I've taken out the `button` argument. All these methods now return a Promise that resolves when the clipboard is sucessfully updated.

2. Fixing (1) led me to re-examine how & why we fire a synthetic `copy` event. We do it when the async clipboard API is used (as opposed to `execCommand('copy')`), but we neither fire it from the same element, nor do we ensure that it behaves the same as the native equivalent (more information can be found in my commit message). Therefore, I've opted to avoid ever firing a synthetic `copy` event, and instead fire a custom `clipboard-copied` event that behaves exactly the same regardless of the clipboard API used.