### PR TITLE
Dispatch clipboard-copy event

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ import 'clipboard-copy-element'
 
 ## Events
 
-After copying to the clipboard, a `clipboard-copied` event is dispatched from
+After copying to the clipboard, a `clipboard-copy` event is dispatched from
 the `<clipboard-copy>` element:
 
 ```js
-document.addEventListener('clipboard-copied', function(event) {
+document.addEventListener('clipboard-copy', function(event) {
   const button = event.target
   button.classList.add('highlight')
 })

--- a/README.md
+++ b/README.md
@@ -52,17 +52,15 @@ import 'clipboard-copy-element'
 
 ## Events
 
-After copying to the clipboard, a [copy][] event is dispatched that can be
-used to notify the user with confirmation, like a tooltip or button highlight.
+After copying to the clipboard, a `clipboard-copied` event is dispatched from
+the `<clipboard-copy>` element:
 
 ```js
-document.addEventListener('copy', function(event) {
-  const button = document.activeElement
+document.addEventListener('clipboard-copied', function(event) {
+  const button = event.target
   button.classList.add('highlight')
 })
 ```
-
-[copy]: https://developer.mozilla.org/en-US/docs/Web/Events/copy
 
 ## Browser support
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -10,7 +10,7 @@
       }
     </style>
     <script>
-      document.addEventListener('copy', function() {
+      document.addEventListener('clipboard-copied', function() {
         const notice = document.getElementById('notice')
         notice.hidden = false
         setTimeout(function() {

--- a/examples/index.html
+++ b/examples/index.html
@@ -10,7 +10,7 @@
       }
     </style>
     <script>
-      document.addEventListener('clipboard-copied', function() {
+      document.addEventListener('clipboard-copy', function() {
         const notice = document.getElementById('notice')
         notice.hidden = false
         setTimeout(function() {

--- a/src/clipboard-copy-element.js
+++ b/src/clipboard-copy-element.js
@@ -5,25 +5,30 @@ import {copyInput, copyNode, copyText} from './clipboard'
 function copy(button: HTMLElement) {
   const id = button.getAttribute('for')
   const text = button.getAttribute('value')
+
+  function trigger() {
+    button.dispatchEvent(new CustomEvent('clipboard-copied', {bubbles: true}))
+  }
+
   if (text) {
-    copyText(text)
+    copyText(text).then(trigger)
   } else if (id) {
     const node = button.ownerDocument.getElementById(id)
-    if (node) copyTarget(node)
+    if (node) copyTarget(node).then(trigger)
   }
 }
 
 function copyTarget(content: Element) {
   if (content instanceof HTMLInputElement || content instanceof HTMLTextAreaElement) {
     if (content.type === 'hidden') {
-      copyText(content.value)
+      return copyText(content.value)
     } else {
-      copyInput(content)
+      return copyInput(content)
     }
   } else if (content instanceof HTMLAnchorElement && content.hasAttribute('href')) {
     copyText(button, content.href)
   } else {
-    copyNode(content)
+    return copyNode(content)
   }
 }
 

--- a/src/clipboard-copy-element.js
+++ b/src/clipboard-copy-element.js
@@ -26,7 +26,7 @@ function copyTarget(content: Element) {
       return copyInput(content)
     }
   } else if (content instanceof HTMLAnchorElement && content.hasAttribute('href')) {
-    copyText(button, content.href)
+    return copyText(content.href)
   } else {
     return copyNode(content)
   }

--- a/src/clipboard-copy-element.js
+++ b/src/clipboard-copy-element.js
@@ -6,26 +6,24 @@ function copy(button: HTMLElement) {
   const id = button.getAttribute('for')
   const text = button.getAttribute('value')
   if (text) {
-    copyText(button, text)
+    copyText(text)
   } else if (id) {
-    copyTarget(button, id)
+    const node = button.ownerDocument.getElementById(id)
+    if (node) copyTarget(node)
   }
 }
 
-function copyTarget(button: Element, id: string) {
-  const content = button.ownerDocument.getElementById(id)
-  if (!content) return
-
+function copyTarget(content: Element) {
   if (content instanceof HTMLInputElement || content instanceof HTMLTextAreaElement) {
     if (content.type === 'hidden') {
-      copyText(button, content.value)
+      copyText(content.value)
     } else {
-      copyInput(button, content)
+      copyInput(content)
     }
   } else if (content instanceof HTMLAnchorElement && content.hasAttribute('href')) {
     copyText(button, content.href)
   } else {
-    copyNode(button, content)
+    copyNode(content)
   }
 }
 

--- a/src/clipboard-copy-element.js
+++ b/src/clipboard-copy-element.js
@@ -7,7 +7,7 @@ function copy(button: HTMLElement) {
   const text = button.getAttribute('value')
 
   function trigger() {
-    button.dispatchEvent(new CustomEvent('clipboard-copied', {bubbles: true}))
+    button.dispatchEvent(new CustomEvent('clipboard-copy', {bubbles: true}))
   }
 
   if (text) {

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -10,12 +10,16 @@ function createNode(text: string): Element {
   return node
 }
 
-export function copyNode(button: Element, node: Element) {
-  if (writeAsync(button, node.textContent)) return
+export function copyNode(node: Element): Promise<void> {
+  if ('clipboard' in navigator) {
+    // eslint-disable-next-line flowtype/no-flow-fix-me-comments
+    // $FlowFixMe Clipboard is not defined in Flow yet.
+    return navigator.clipboard.writeText(node.textContent)
+  }
 
   const selection = getSelection()
   if (selection == null) {
-    return
+    return Promise.reject(new Error())
   }
 
   selection.removeAllRanges()
@@ -26,22 +30,34 @@ export function copyNode(button: Element, node: Element) {
 
   document.execCommand('copy')
   selection.removeAllRanges()
+  return Promise.resolve()
 }
 
-export function copyText(button: Element, text: string) {
-  if (writeAsync(button, text)) return
+export function copyText(text: string): Promise<void> {
+  if ('clipboard' in navigator) {
+    // eslint-disable-next-line flowtype/no-flow-fix-me-comments
+    // $FlowFixMe Clipboard is not defined in Flow yet.
+    return navigator.clipboard.writeText(text)
+  }
 
   const body = document.body
-  if (!body) return
+  if (!body) {
+    return Promise.reject(new Error())
+  }
 
   const node = createNode(text)
   body.appendChild(node)
-  copyNode(button, node)
+  copyNode(node)
   body.removeChild(node)
+  return Promise.resolve()
 }
 
-export function copyInput(button: Element, node: HTMLInputElement | HTMLTextAreaElement) {
-  if (writeAsync(button, node.value)) return
+export function copyInput(node: HTMLInputElement | HTMLTextAreaElement): Promise<void> {
+  if ('clipboard' in navigator) {
+    // eslint-disable-next-line flowtype/no-flow-fix-me-comments
+    // $FlowFixMe Clipboard is not defined in Flow yet.
+    return navigator.clipboard.writeText(node.value)
+  }
 
   node.select()
   document.execCommand('copy')
@@ -49,14 +65,5 @@ export function copyInput(button: Element, node: HTMLInputElement | HTMLTextArea
   if (selection != null) {
     selection.removeAllRanges()
   }
-}
-
-function writeAsync(button: Element, text: string): boolean {
-  const clipboard = navigator.clipboard
-  if (!clipboard) return false
-
-  clipboard.writeText(text).then(function() {
-    button.dispatchEvent(new CustomEvent('copy', {bubbles: true}))
-  })
-  return true
+  return Promise.resolve()
 }

--- a/test/test.js
+++ b/test/test.js
@@ -65,7 +65,7 @@ describe('clipboard-copy element', function() {
       })
 
       whenCopied = new Promise(resolve => {
-        document.addEventListener('copy', () => resolve(copiedText), {once: true})
+        document.addEventListener('clipboard-copied', () => resolve(copiedText), {once: true})
       })
     })
 

--- a/test/test.js
+++ b/test/test.js
@@ -65,7 +65,7 @@ describe('clipboard-copy element', function() {
       })
 
       whenCopied = new Promise(resolve => {
-        document.addEventListener('clipboard-copied', () => resolve(copiedText), {once: true})
+        document.addEventListener('clipboard-copy', () => resolve(copiedText), {once: true})
       })
     })
 


### PR DESCRIPTION
Cherry picks @mislav's event dispatch commits from #7 so we can listen for a consistent custom event name rather than trying to emulate the native `copy` event behavior for backwards compatibility.