### PR TITLE
Add TS window declaration for ClipboardCopyElement

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,6 @@ export default class ClipboardCopyElement extends HTMLElement {
 
 declare global {
   interface Window {
-    ClipboardCopyElement: ClipboardCopyElement
+    ClipboardCopyElement: typeof ClipboardCopyElement
   }
 }


### PR DESCRIPTION
The TypeScript definition is incomplete as it doesn't properly reflect the assignment to Window.

This PR adds the declaration of `ClipboardCopyElement` to the global window object, as that mutation is happening within the code and so should be reflected in the types.

 Refs https://github.com/github/application-architecture/issues/58