### PR TITLE
Include module in Flow declaration

### DIFF
--- a/src/clipboard-copy-element.js.flow
+++ b/src/clipboard-copy-element.js.flow
@@ -1,6 +1,8 @@
 /* @flow strict */
 
-declare export default class ClipboardCopyElement extends HTMLElement {
-  get value(): string;
-  set value(value: string): void;
+declare module '@github/clipboard-copy-element' {
+  declare export default class ClipboardCopyElement extends HTMLElement {
+    get value(): string;
+    set value(value: string): void;
+  }
 }


### PR DESCRIPTION
Fixes an error importing the class.

```js
import ClipboardCopyElement from '@github/clipboard-copy-element
```
> Error: Importing from an untyped module makes it `any` and is not safe!