### PR TITLE
Add support for Shadow DOM follow-up 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2365,9 +2365,9 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.109.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.109.0.tgz",
-      "integrity": "sha512-tpcMTpAGIRivYhFV3KJq+zHI2HzcXo8MoGe9pXS4G/UZuey2Faq/e8/gdph2WF0erRlML5hmwfwiq7v9c25c7w==",
+      "version": "0.111.1",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.111.1.tgz",
+      "integrity": "sha512-fOFFy4rsvV4zYXUqpNY2bChpzEMYbmumO6DlbcpndbJIHY3W8+UzyiWb8+iRDf2ME1YJgTIvKSJCzHpQ40OBOQ==",
       "dev": true
     },
     "follow-redirects": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "chai": "^4.2.0",
     "eslint": "^6.5.1",
     "eslint-plugin-github": "^3.1.3",
-    "flow-bin": "^0.109.0",
+    "flow-bin": "^0.111.1",
     "karma": "^4.3.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.0",

--- a/src/clipboard-copy-element.js
+++ b/src/clipboard-copy-element.js
@@ -14,6 +14,7 @@ function copy(button: HTMLElement) {
     copyText(text).then(trigger)
   } else if (id) {
     const root = 'getRootNode' in Element.prototype ? button.getRootNode() : button.ownerDocument
+    if (!(root instanceof Document || ('ShadowRoot' in window && root instanceof ShadowRoot))) return
     const node = root.getElementById(id)
     if (node) copyTarget(node).then(trigger)
   }

--- a/test/test.js
+++ b/test/test.js
@@ -188,7 +188,7 @@ describe('clipboard-copy element', function() {
       defineClipboard(nativeClipboard)
     })
 
-    it('node', function() {
+    it('copies from within its shadow root', function() {
       const shadow = document.querySelector('#shadow')
       shadow.shadowRoot.querySelector('clipboard-copy').click()
 

--- a/test/test.js
+++ b/test/test.js
@@ -37,16 +37,6 @@ describe('clipboard-copy element', function() {
 
   describe('target element', function() {
     const nativeClipboard = navigator.clipboard
-    function defineClipboard(customClipboard) {
-      Object.defineProperty(navigator, 'clipboard', {
-        enumerable: false,
-        configurable: true,
-        get() {
-          return customClipboard
-        }
-      })
-    }
-
     let whenCopied
     beforeEach(function() {
       const container = document.createElement('div')
@@ -163,16 +153,6 @@ describe('clipboard-copy element', function() {
 
   describe('shadow DOM context', function() {
     const nativeClipboard = navigator.clipboard
-    function defineClipboard(customClipboard) {
-      Object.defineProperty(navigator, 'clipboard', {
-        enumerable: false,
-        configurable: true,
-        get() {
-          return customClipboard
-        }
-      })
-    }
-
     let whenCopied
     beforeEach(function() {
       const container = document.createElement('div')
@@ -218,3 +198,13 @@ describe('clipboard-copy element', function() {
     })
   })
 })
+
+function defineClipboard(customClipboard) {
+  Object.defineProperty(navigator, 'clipboard', {
+    enumerable: false,
+    configurable: true,
+    get() {
+      return customClipboard
+    }
+  })
+}


### PR DESCRIPTION
I wanted to resolve #9, so did some digging on the lint failure. It's been a while since we responded to the PR last so I figured I'd take on doing the rest, instead of prompting the author to update their PR. 😬 

- Upgrade Flow to fix the type error, where `shadowRoot` does not have `getElementById`. It was added in https://github.com/facebook/flow/commit/72b6397d7f614a56c67a92591d0996ef15754805.
- Add test for `shadowRoot` context. Before this patch:
```
FAILED TESTS:
  clipboard-copy element
    shadow DOM context
      ✖ node
        HeadlessChrome 78.0.3904 (Mac OS X 10.14.6)
      AssertionError: expected 'Target in Document' to equal 'Target in shadowRoot'
          at test.js:216:16
```

cc @jorgecasar