### PR TITLE
Use copyText to copy input value

### DIFF
--- a/src/clipboard-copy-element.js
+++ b/src/clipboard-copy-element.js
@@ -1,6 +1,6 @@
 /* @flow strict */
 
-import {copyInput, copyNode, copyText} from './clipboard'
+import {copyNode, copyText} from './clipboard'
 
 function copy(button: HTMLElement) {
   const id = button.getAttribute('for')
@@ -22,11 +22,7 @@ function copy(button: HTMLElement) {
 
 function copyTarget(content: Element) {
   if (content instanceof HTMLInputElement || content instanceof HTMLTextAreaElement) {
-    if (content.type === 'hidden') {
-      return copyText(content.value)
-    } else {
-      return copyInput(content)
-    }
+    return copyText(content.value)
   } else if (content instanceof HTMLAnchorElement && content.hasAttribute('href')) {
     return copyText(content.href)
   } else {

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -51,7 +51,3 @@ export function copyText(text: string): Promise<void> {
   body.removeChild(node)
   return Promise.resolve()
 }
-
-export function copyInput(node: HTMLInputElement | HTMLTextAreaElement): Promise<void> {
-  return copyText(node.value)
-}

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -53,17 +53,5 @@ export function copyText(text: string): Promise<void> {
 }
 
 export function copyInput(node: HTMLInputElement | HTMLTextAreaElement): Promise<void> {
-  if ('clipboard' in navigator) {
-    // eslint-disable-next-line flowtype/no-flow-fix-me-comments
-    // $FlowFixMe Clipboard is not defined in Flow yet.
-    return navigator.clipboard.writeText(node.value)
-  }
-
-  node.select()
-  document.execCommand('copy')
-  const selection = getSelection()
-  if (selection != null) {
-    selection.removeAllRanges()
-  }
-  return Promise.resolve()
+  return copyText(node.value)
 }


### PR DESCRIPTION
Fixes #15.

Upon closer inspection I noticed that `for` attribute is only not working in iOS when it's pointing to a textarea.

Instead of trying to fulfill the non-spec (potentially changing) requirements listed in [the stackoverflow answers](https://stackoverflow.com/questions/34045777/copy-to-clipboard-using-javascript-in-ios), I think we should just not rely on copying from `<input>` when we have methods for copying text from a new node.

Manually tested in:

- iOS 13.2
- Android 9/Chrome latest via BrowserStack
- Opera, Firefox latest on Windows 10 via BrowserStack
- Firefox/Safari/Chrome latest on macOS