### PR TITLE
Update link to polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Browsers without native [custom element support][support] require a [polyfill][]
 - Microsoft Edge
 
 [support]: https://caniuse.com/#feat=custom-elementsv1
-[polyfill]: https://github.com/webcomponents/custom-elements
+[polyfill]: https://github.com/webcomponents/polyfills/tree/master/packages/custom-elements
 
 ## Development
 


### PR DESCRIPTION
[webcomponents/custom-elements](https://github.com/webcomponents/custom-elements) moved to the [webcomponents/polyfills](https://github.com/webcomponents/polyfills) monorepo.