### PR TITLE
Fix import error in example page

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -2,8 +2,8 @@
 <html>
   <head>
     <title>Clipboard copy examples</title>
-    <script src="https://unpkg.com/@github/clipboard-copy-element@latest" defer></script>
-    <!-- <script src="../dist/index.js" defer></script> -->
+    <script type="module" src="https://unpkg.com/@github/clipboard-copy-element@latest"></script>
+    <!-- <script type="module" src="../dist/index.js"></script> -->
     <style>
       clipboard-copy {
         -webkit-appearance: button;


### PR DESCRIPTION
Fixes `Uncaught SyntaxError: Cannot use import statement outside a module` in https://github.github.io/clipboard-copy-element/examples/