### PR TITLE
Allow disabling element

### DIFF
--- a/src/clipboard-copy-element.ts
+++ b/src/clipboard-copy-element.ts
@@ -8,6 +8,11 @@ async function copy(button: HTMLElement) {
     button.dispatchEvent(new CustomEvent('clipboard-copy', {bubbles: true}))
   }
 
+  if (button.getAttribute('aria-disabled') === 'true') {
+    button.dispatchEvent(new CustomEvent('clipboard-copy-nothing', {bubbles: true}))
+    return
+  }
+
   if (text) {
     await copyText(text)
     trigger()

--- a/src/clipboard-copy-element.ts
+++ b/src/clipboard-copy-element.ts
@@ -9,7 +9,6 @@ async function copy(button: HTMLElement) {
   }
 
   if (button.getAttribute('aria-disabled') === 'true') {
-    button.dispatchEvent(new CustomEvent('clipboard-copy-nothing', {bubbles: true}))
     return
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -42,6 +42,7 @@ describe('clipboard-copy element', function () {
   describe('target element', function () {
     const nativeClipboard = navigator.clipboard
     let whenCopied
+
     beforeEach(function () {
       const container = document.createElement('div')
       container.innerHTML = `
@@ -56,14 +57,13 @@ describe('clipboard-copy element', function () {
           copiedText = text
           return Promise.resolve()
         },
+        readText() {
+          return Promise.resolve(copiedText)
+        },
       })
 
       whenCopied = new Promise(resolve => {
         document.addEventListener('clipboard-copy', () => resolve(copiedText), {
-          once: true,
-        })
-
-        document.addEventListener('clipboard-copy-nothing', () => resolve(null), {
           once: true,
         })
       })
@@ -162,14 +162,21 @@ describe('clipboard-copy element', function () {
 
       const button = document.querySelector('clipboard-copy')
       button.setAttribute('aria-disabled', 'true')
-      let fired = false;
-      document.addEventListener('clipboard-copy', () => { fired = true }, { once: true })
-      
+
+      let fired = false
+      document.addEventListener(
+        'clipboard-copy',
+        () => {
+          fired = true
+        },
+        {once: true},
+      )
+
       button.click()
-      
+
       await new Promise(setTimeout)
-      assert.equal(fired, false);
-      assert.equal(null, text)
+      assert.equal(fired, false)
+      assert.equal(null, await navigator.clipboard.readText())
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -162,9 +162,13 @@ describe('clipboard-copy element', function () {
 
       const button = document.querySelector('clipboard-copy')
       button.setAttribute('aria-disabled', 'true')
+      let fired = false;
+      document.addEventListener('clipboard-copy', () => { fired = true }, { once: true })
+      
       button.click()
-
-      const text = await whenCopied
+      
+      await new Promise(setTimeout)
+      assert.equal(fired, false);
       assert.equal(null, text)
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -62,6 +62,10 @@ describe('clipboard-copy element', function () {
         document.addEventListener('clipboard-copy', () => resolve(copiedText), {
           once: true,
         })
+
+        document.addEventListener('clipboard-copy-nothing', () => resolve(null), {
+          once: true,
+        })
       })
     })
 
@@ -148,6 +152,20 @@ describe('clipboard-copy element', function () {
 
       const text = await whenCopied
       assert.equal(text, 'I am a link')
+    })
+
+    it('does not copy when disabled', async function () {
+      const target = document.createElement('div')
+      target.innerHTML = 'Hello world!'
+      target.id = 'copy-target'
+      document.body.append(target)
+
+      const button = document.querySelector('clipboard-copy')
+      button.setAttribute('aria-disabled', 'true')
+      button.click()
+
+      const text = await whenCopied
+      assert.equal(null, text)
     })
   })
 

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -1,15 +1,18 @@
 import {esbuildPlugin} from '@web/dev-server-esbuild'
 import {playwrightLauncher} from '@web/test-runner-playwright'
-const browser = product =>
+const getBrowser = product =>
   playwrightLauncher({
     product,
+    createBrowserContext: ({browser}) => {
+      return browser.newContext({permissions: ['clipboard-read']})
+    },
   })
 
 export default {
   files: ['test/*'],
   nodeResolve: true,
   plugins: [esbuildPlugin({ts: true, target: 'es2020'})],
-  browsers: [browser('chromium')],
+  browsers: [getBrowser('chromium')],
   testFramework: {
     config: {
       timeout: 1000,


### PR DESCRIPTION
This PR makes it so `<clipboard-copy aria-disabled="true">` doesn't copy anything when clicked. Because of the way the tests are written, I introduced a new custom event, `clipboard-copy-nothing`, that fires whenever a disabled element is clicked. Definitely open to suggestions around how to avoid a second event 😅 I tried waiting for the promise to time out, but that seems awful.