### PR TITLE
Potential fixes for 2 code scanning alerts

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,8 @@
 name: Node CI
 
 on: push
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [created]


### PR DESCRIPTION

Potential fixes for 2 code scanning alerts from the [Copilot AutoFix: Missing Permissions in Workflows](https://github.com/orgs/github/security/campaigns/21) security campaign:
- https://github.com/github/clipboard-copy-element/security/code-scanning/2
The best way to fix this problem is to add a `permissions` block at the root level of the workflow file (above the `jobs:` key), explicitly specifying the minimal required permissions for the workflow—in this case, setting `contents: read`. This will ensure that all jobs in the workflow run with only read access to the repository contents, unless overridden by a more specific permissions block. This change should be implemented directly within the `.github/workflows/nodejs.yml` file above the `jobs:` section.
  


- https://github.com/github/clipboard-copy-element/security/code-scanning/1
To fix the issue, add a `permissions` block at the workflow or the job level in `.github/workflows/publish.yml`. The best location is at the root, above or below the `on` block (before `jobs:`), to apply the minimal required permissions to all jobs in the workflow. For most publishing tasks, `contents: read` is sufficient unless the workflow specifically needs to write to contents, issues, or packages. If additional permissions are justifiably needed (e.g., for uploading assets, creating releases, etc.), adjust accordingly. For the shown snippet, setting `contents: read` at the root suffices.
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
