### PR TITLE
Modify publish workflow to include id-token permission

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: Publish
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   release:
@@ -22,6 +23,4 @@ jobs:
       - run: npm version ${TAG_NAME} --git-tag-version=false
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
-      - run: npm whoami; npm --ignore-scripts publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+      - run: npm --ignore-scripts publish --provenance


### PR DESCRIPTION
Part of: https://github.com/github/web-systems/issues/4309

Updated publish workflow to include permissions and modify npm publish commands as we've migrated to OIDC.